### PR TITLE
feat: allow company customization and improve card link extraction

### DIFF
--- a/libs/mcp-pr-command/README.md
+++ b/libs/mcp-pr-command/README.md
@@ -85,23 +85,6 @@ npm i -g mcp-pr-command
 
 After installation, you need to configure it in VS Code (see next section).
 
-### Example: infer card/pr links
-
-The MCP server supports runtime inference of card and PR links by passing a JSON options object. Example:
-
-```bash
-mcp-pr-command --mcp-options '{"cardLinkInferPattern":"[\w\-]+/(\d+)/(\d+)", "cardLinkWebSite":"https://link.com","cartPathLinkReplacePattern":"$1/card/$2/details"}'
-```
-
-In the example above the server will use the provided regular pattern to extract card identifiers from text and map them into the `prLinkInferPattern` template.
-
-You can also inform a config option file like this:
-
-
-```bash
-mcp-pr-command --mcp-options-file mcp-pr-command-options.json
-```
-
 ## How to configure it in VS Code for Copilot
 
 The simplest way to register an MCP server is using the MCP extension command inside VS Code:
@@ -128,4 +111,49 @@ The simplest way to register an MCP server is using the MCP extension command in
 4. Confirm and save.
 
 > This will register the MCP server and allow Copilot to use these tools to generate PR descriptions and rewrite commits!
-> Remember you can add --mcp-options or --mcp-options-file to the call so you can customize card link inferring from branch
+> Remember you can add --mcp-options or --mcp-options-file to the call so you can customize card link inferring from branch.
+
+## Examples
+
+### Infer card/pr links
+
+The MCP server supports runtime inference of card and PR links by passing a JSON options object. Example:
+
+```bash
+mcp-pr-command --mcp-options '{"branchCardIdExtractPattern":"[\w\-]+/(\d+)/(\d+)", "cardLinkWebSite":"https://link.com","cartPathLinkReplacePattern":"$1/card/$2/details"}'
+```
+
+In the example above the server will use the provided regular pattern to extract card identifiers from text and map them into the `prLinkInferPattern` template.
+
+You can also inform a config option file like this:
+
+
+```bash
+mcp-pr-command --mcp-options-file mcp-pr-command-options.json
+```
+
+### Node.js usage (programmatic)
+
+You can also use this library directly from Node.js, which is ideal for organizations that want to set up their own CLI wrapper or enforce specific options programmatically. This allows you to start the MCP PR Command server with custom options, without relying on CLI arguments or config files.
+
+```js
+// my-mcp-server.js
+#!/usr/bin/env node
+const { startServer } = require('mcp-pr-command');
+
+startServer({
+   cardLinkWebSite: 'https://link.com',
+   cartPathLinkReplacePattern: '$1/card/$2/details',
+   branchCardIdExtractPattern: '[\\w\\-]+/(\\d+)/(\\d+)',
+   complementaryMcpDescription: 'Custom org PR workflow',
+   // ...any other options from McpPRCommandOptions
+});
+```
+
+You can then run your server with:
+
+```bash
+node my-mcp-server.js
+```
+
+This approach is recommended for organizations with well-established parameters or custom workflows. You can fully control the server's configuration in code, integrate with other systems, or wrap it in your own CLI.

--- a/libs/mcp-pr-command/src/internal/attempt.ts
+++ b/libs/mcp-pr-command/src/internal/attempt.ts
@@ -1,20 +1,30 @@
-export function attempt<T>(cb: () => T): T | undefined;
-export function attempt<T>(cb: () => Promise<T>): Promise<T | undefined>;
-export function attempt<T>(
+export function attempt<T, E = undefined>(
+	cb: () => T,
+	catchCb?: (error: unknown) => E,
+): T | E;
+export function attempt<T, E = undefined>(
+	cb: () => Promise<T>,
+	catchCb?: (error: unknown) => E,
+): Promise<T | E>;
+export function attempt<T, E = undefined>(
 	cb: () => T | Promise<T>,
-): T | Promise<T | undefined> | undefined {
+	catchCb?: (error: unknown) => E,
+): T | E | Promise<T | E> {
 	try {
 		const res = cb();
 		if (res && typeof (res as Promise<T>).then === 'function') {
-			return (res as Promise<T>).then((v) => v).catch(() => undefined);
+			return (res as Promise<T>).then((v) => v).catch((e) => catchCb?.(e) as E);
 		}
 		return res as T;
-	} catch {
-		return undefined;
+	} catch (error) {
+		return catchCb?.(error) as E;
 	}
 }
 
 export const attemptCB =
-	<T extends (...args: unknown[]) => unknown>(cb: T) =>
+	<R, T extends (...args: unknown[]) => R | Promise<R>, E = undefined>(
+		cb: T,
+		catchCb?: (error: unknown) => E,
+	) =>
 	(...args: Parameters<T>) =>
-		attempt(() => cb(...args));
+		attempt(() => cb(...args), catchCb);

--- a/libs/mcp-pr-command/src/internal/card-link-utils.ts
+++ b/libs/mcp-pr-command/src/internal/card-link-utils.ts
@@ -26,7 +26,7 @@ export function inferCardLinkFromBranch(
 ): string | undefined {
 	if (
 		!branch ||
-		!context.cardLinkInferPattern ||
+		!context.branchCardIdExtractPattern ||
 		!context.prLinkInferPattern ||
 		typeof branch !== 'string'
 	) {
@@ -35,7 +35,7 @@ export function inferCardLinkFromBranch(
 	if (isValidISODateString(branch)) return undefined;
 	// Convert branch using patterns
 	const link = branch.replace(
-		context.cardLinkInferPattern,
+		context.branchCardIdExtractPattern,
 		context.prLinkInferPattern,
 	);
 	if (!link || link === branch) return undefined;

--- a/libs/mcp-pr-command/src/internal/index.ts
+++ b/libs/mcp-pr-command/src/internal/index.ts
@@ -1,6 +1,6 @@
 export * from './attempt';
 export * from './branch-utils';
-export * from './buildCopilotPrompt';
+export * from './build-copilot-prompt';
 export * from './card-link-utils';
 export * from './context';
 export * from './get-error-message';

--- a/libs/mcp-pr-command/src/internal/internal-options.ts
+++ b/libs/mcp-pr-command/src/internal/internal-options.ts
@@ -1,6 +1,7 @@
 export interface InternalOptions {
-	cardLinkInferPattern?: RegExp;
+	branchCardIdExtractPattern?: RegExp;
 	cardLinkWebSitePattern?: RegExp;
 	prLinkInferPattern?: string;
 	language?: string;
+	basePullRequestPrompt?: string;
 }

--- a/libs/mcp-pr-command/src/internal/shell-utils.ts
+++ b/libs/mcp-pr-command/src/internal/shell-utils.ts
@@ -4,28 +4,23 @@ import {
 	ExecFileSyncOptionsWithStringEncoding,
 	ExecSyncOptionsWithStringEncoding,
 } from 'child_process';
+import { attempt } from './attempt';
 
-export function safeExecFileSync(
+export const safeExecFileSync = (
 	cmd: string,
 	args: string[] = [],
 	opts?: ExecFileSyncOptionsWithStringEncoding,
-): string | Buffer | null {
-	try {
-		return execFileSync(cmd, args, opts);
-	} catch {
-		return null;
-	}
-}
+): string | Buffer | null =>
+	attempt(
+		() => execFileSync(cmd, args, opts),
+		() => null,
+	);
 
-export function safeExecSync(
+export const safeExecSync = (
 	cmd: string,
 	opts?: ExecSyncOptionsWithStringEncoding,
-): string | Buffer | null {
-	try {
-		return execSync(cmd, opts);
-	} catch {
-		return null;
-	}
-}
-
-export default { safeExecFileSync, safeExecSync };
+): string | Buffer | null =>
+	attempt(
+		() => execSync(cmd, opts),
+		() => null,
+	);

--- a/libs/mcp-pr-command/src/main.ts
+++ b/libs/mcp-pr-command/src/main.ts
@@ -4,11 +4,20 @@ import * as tools from './tools';
 import { fluentObject } from '@codibre/fluent-iterable';
 import { McpPRCommandOptions } from './mcp-pr-command-options';
 
+/**
+ * Starts the MCP PR Command server with the provided options.
+ *
+ * This function initializes the MCP server, configures the context with the given options,
+ * sets up card link and PR link inference patterns, registers all available tools, and
+ * connects the server to the standard I/O transport. If the server fails to start, the process exits with an error.
+ *
+ * @param options - Optional configuration for the MCP PR Command server, including card link website,
+ *   card path link pattern, language, and other behavioral settings. See {@link McpPRCommandOptions} for details.
+ */
 export function startServer(options?: McpPRCommandOptions) {
 	if (options) {
 		const { cardLinkWebSite, cartPathLinkReplacePattern } = options;
-		context.cardLinkInferPattern = options.cardLinkInferPattern;
-		context.language = options.language;
+		Object.assign(context, options);
 		if (cardLinkWebSite) {
 			context.cardLinkWebSitePattern = new RegExp(
 				`/${cardLinkWebSite}\/[^\s)]+/g`,
@@ -24,9 +33,15 @@ export function startServer(options?: McpPRCommandOptions) {
 			}
 		}
 	}
+	let title =
+		'MCP used for Pull Request opening and updating, and commit messages rewriting';
+	if (options?.complementaryMcpDescription) {
+		title += ` - ${options.complementaryMcpDescription}`;
+	}
 	const server = new McpServer({
 		name: 'mcp-pr-command',
 		version: packageInfo.version ?? '0.0.0',
+		title,
 	});
 
 	fluentObject(tools)

--- a/libs/mcp-pr-command/src/mcp-pr-command-options.ts
+++ b/libs/mcp-pr-command/src/mcp-pr-command-options.ts
@@ -1,6 +1,89 @@
+/**
+ * Options for configuring the MCP PR Command behavior.
+ */
 export interface McpPRCommandOptions {
-	cardLinkInferPattern?: RegExp;
+	/**
+	 * Regular expression pattern used to extract card or ticket IDs from a branch name.
+	 * The extracted ID(s) can be used in cartPathLinkReplacePattern to generate card links.
+	 *
+	 * @example
+	 *   // For branch name: 'feature/PROJ-1234-add-login'
+	 *   branchCardIdExtractPattern: /PROJ-\d+/g
+	 */
+	branchCardIdExtractPattern?: RegExp;
+
+	/**
+	 * Base URL of the card tracking website (e.g., Jira, Kanbanize) for constructing card links.
+	 *
+	 * @example
+	 *   cardLinkWebSite: 'https://tracker.example.com'
+	 */
 	cardLinkWebSite?: string;
+
+	/**
+	 * Pattern to replace in the card path when generating card links.
+	 * Used together with branchCardIdExtractPattern and cardLinkWebSite to build the full card URL.
+	 *
+	 * For example, if your branch name is 'feature/PROJ-1234-add-login',
+	 *   branchCardIdExtractPattern: /PROJ-\d+/g
+	 *   cardLinkWebSite: 'https://tracker.example.com'
+	 *   cartPathLinkReplacePattern: '/board/123/card/{cardId}'
+	 * The resulting card link would be:
+	 *   'https://tracker.example.com/board/123/card/PROJ-1234'
+	 */
 	cartPathLinkReplacePattern?: string;
+
+	/**
+	 * Preferred language for prompts and messages (e.g., 'en', 'pt-br', 'english', 'portuguese').
+	 * Can be a language code or full language name, as used in conversational contexts.
+	 *
+	 * @example
+	 *   language: 'en'
+	 *   language: 'pt-br'
+	 *   language: 'english'
+	 *   language: 'portuguese'
+	 */
 	language?: string;
+
+	/**
+	 * Default prompt to use when generating PR descriptions or commit messages.
+	 * You can use the %LANGUAGE% placeholder to dynamically insert the selected language into the prompt.
+	 *
+	 * @example
+	 *   defaultPrompt: `## GENERAL INSTRUCTIONS\n
+	 * - PR must be written in %LANGUAGE%, unless specified otherwise in .github/copilot-instructions.md\n
+	 * - ALWAYS respect PR template when present.\n
+	 * - If current PR exists, use its content as context, but enforce PR template. Maybe current PR is not following it\n
+	 * - Focus on intent and user-visible impact (what changed and why)\n
+	 *
+	 * ## DESCRIPTION AND TITLE INSTRUCTIONS:\n
+	 * - Explain the change made based on commit messages and diff provided\n
+	 * - Title must be concise, single-line summary with no special characters.\n
+	 * - Context of the problem being solved must be included\n
+	 *
+	 * ## COMMIT FORMATTING INSTRUCTIONS:\n
+	 * - Omit trivial commits (e.g. 'fix lint') EXCEPT merge commits that reference PRs with useful context\n
+	 * - For commits referencing PRs (e.g. "Merge pull request #123"), ALWAYS preserve the PR reference in the summary\n
+	 * - Format as bullet points with '- ' (no hashes, no extra markup)\n
+	 *
+	 * ## CARD LINK INSTRUCTIONS:\n
+	 * - When having a PR template with a strong link placeholder, try to comply to suggested format\n
+	 *   - Example of place holder: [#TASK_NUMBER](https://link.com/ctrl_board/BOARD_NUMBER/cards/TASK_NUMBER/details/). In this case, extract TASK_NUMBER from url to fill the place holder\n
+	 *   - If a undocumented pattern is found, try to follow it as best as possible\n
+	 * - Information from cards must be fetched from Kanbanize and included in the PR description\n
+	 *   - Summarize only the relevant parts if the description is too long\n
+	 *   - Respect template structure when adding card links.\n
+	 *   - Card information may go just below card link.\n   * `
+	 */
+	defaultPrompt?: string;
+
+	/**
+	 * Complementary description to be used by the MCP for additional context.
+	 * You can use this if you want to provide extra information that fits to your
+	 * enterprise usage.
+	 *
+	 * Example:
+	 *  MCP to be used only for [company name] project, with REPO organization being [organization name].
+	 **/
+	complementaryMcpDescription?: string;
 }

--- a/libs/mcp-pr-command/src/tools/replace-commit-messages.tool.ts
+++ b/libs/mcp-pr-command/src/tools/replace-commit-messages.tool.ts
@@ -75,7 +75,7 @@ Commits must have good description for changelogs generation and for other tools
 				content: [
 					{
 						type: 'text',
-						text: `Operação não permitida: a branch '${current}' é uma branch protegida do schema. Apenas branches de feature/fix podem ter o histórico alterado. Branches protegidas: ${protectedList}`,
+						text: `Operation not allowed: branch '${current}' is a protected schema branch. Only feature/fix branches can have their history altered. Protected branches: ${protectedList}`,
 					},
 				],
 				structuredContent: { error: 'protected_branch', replaced: 0 },
@@ -265,7 +265,7 @@ fi
 				content: [
 					{
 						type: 'text',
-						text: `Failed while rewriting commits: ${msg}. Backup disponível em tag: ${backupTag}`,
+						text: `Failed while rewriting commits: ${msg}. Backup available at tag: ${backupTag}`,
 					},
 				],
 				structuredContent: { error: msg, replaced: 0, backupTag },
@@ -294,7 +294,7 @@ fi
 				content: [
 					{
 						type: 'text',
-						text: `Failed to update branch or push changes: ${msg}. Backup disponível em tag: ${backupTag}`,
+						text: `Failed to update branch or push changes: ${msg}. Backup available at tag: ${backupTag}`,
 					},
 				],
 				structuredContent: { error: msg, replaced: 0, backupTag },

--- a/libs/mcp-pr-command/test/unit/internal/build-copilot-prompt.no-language.spec.ts
+++ b/libs/mcp-pr-command/test/unit/internal/build-copilot-prompt.no-language.spec.ts
@@ -1,0 +1,27 @@
+import { buildCopilotPrompt } from '../../../src/internal/build-copilot-prompt';
+import { context } from '../../../src/internal/context';
+
+describe('buildCopilotPrompt (no language in context)', () => {
+	beforeAll(() => {
+		// Remove language from context
+		delete context.language;
+	});
+
+	it('should use the default language placeholder when context.language is not set', () => {
+		const prompt = buildCopilotPrompt({ changesFile: 'changes.txt' });
+		expect(prompt).toContain(
+			'same language of README.MD, commits or pull request template',
+		);
+		expect(prompt).toContain('changes.txt');
+	});
+
+	it('should replace placeholder in custom basePullRequestPrompt', () => {
+		const oldPrompt = context.basePullRequestPrompt;
+		context.basePullRequestPrompt = 'Hello %LANGUAGE%!';
+		const prompt = buildCopilotPrompt({ changesFile: 'file.txt' });
+		expect(prompt).toContain(
+			'Hello same language of README.MD, commits or pull request template!',
+		);
+		context.basePullRequestPrompt = oldPrompt;
+	});
+});

--- a/libs/mcp-pr-command/test/unit/internal/build-copilot-prompt.with-language.spec.ts
+++ b/libs/mcp-pr-command/test/unit/internal/build-copilot-prompt.with-language.spec.ts
@@ -1,0 +1,26 @@
+import { buildCopilotPrompt } from '../../../src/internal/build-copilot-prompt';
+import { context } from '../../../src/internal/context';
+
+describe('buildCopilotPrompt (with language in context)', () => {
+	const testLanguage = 'Portuguese';
+	beforeAll(() => {
+		context.language = testLanguage;
+	});
+	afterAll(() => {
+		delete context.language;
+	});
+
+	it('should use the language from context in the prompt', () => {
+		const prompt = buildCopilotPrompt({ changesFile: 'changes.txt' });
+		expect(prompt).toContain(testLanguage);
+		expect(prompt).toContain('changes.txt');
+	});
+
+	it('should replace placeholder in custom basePullRequestPrompt', () => {
+		const oldPrompt = context.basePullRequestPrompt;
+		context.basePullRequestPrompt = 'Hello %LANGUAGE%!';
+		const prompt = buildCopilotPrompt({ changesFile: 'file.txt' });
+		expect(prompt).toContain('Hello Portuguese!');
+		context.basePullRequestPrompt = oldPrompt;
+	});
+});

--- a/libs/mcp-pr-command/test/unit/main.spec.ts
+++ b/libs/mcp-pr-command/test/unit/main.spec.ts
@@ -5,7 +5,7 @@ const McpServerMock = jest.fn().mockImplementation((opts) => ({
 	options: opts,
 }));
 const context: InternalOptions = {
-	cardLinkInferPattern: undefined,
+	branchCardIdExtractPattern: undefined,
 	cardLinkWebSitePattern: undefined,
 	prLinkInferPattern: undefined,
 };
@@ -41,7 +41,7 @@ const { startServer } = require('../../src/main');
 describe('startServer', () => {
 	beforeEach(() => {
 		// reset context
-		context.cardLinkInferPattern = undefined;
+		context.branchCardIdExtractPattern = undefined;
 		context.cardLinkWebSitePattern = undefined;
 		context.prLinkInferPattern = undefined;
 	});
@@ -71,10 +71,10 @@ describe('startServer', () => {
 		startServer({
 			cardLinkWebSite: 'https://example.com/',
 			cartPathLinkReplacePattern: '/path/to/pr',
-			cardLinkInferPattern: 'CARD-\\d+',
+			branchCardIdExtractPattern: 'CARD-\\d+',
 		} as any);
 
-		expect(context.cardLinkInferPattern).toBe('CARD-\\d+');
+		expect(context.branchCardIdExtractPattern).toBe('CARD-\\d+');
 		// cardLinkWebSitePattern should be a RegExp when created
 		expect(context.cardLinkWebSitePattern).toBeInstanceOf(RegExp);
 		expect(context.prLinkInferPattern).toBe('https://example.com/path/to/pr');


### PR DESCRIPTION
### 🔨 What does this PR do?

Enables company customization and improves card link extraction from branch names. Refactors options and documentation for greater flexibility and clarity, and adds programmatic and CLI usage examples.

## Type

- [x] addition
- [x] change

## Objectives

- Refactor `cardLinkInferPattern` to `branchCardIdExtractPattern` throughout the codebase
- Allow advanced customization via options and config file
- Update and expand README examples, including Node.js programmatic usage
- Improve unit tests for scenarios with and without language defined
- Adjust messages and instructions for internationalization and clarity
- Fix minor bugs and inconsistencies in internal utilities

## Screenshot

<!-- Include an image of the solution if necessary or if it helps to show the change. -->

## Tests/How to test?

- Unit tests updated and expanded (`libs/mcp-pr-command/test/unit/internal/`)
- Test README examples to ensure CLI and Node.js usage works as expected

## Deploy

- Backward compatible, but integrations relying on `cardLinkInferPattern` should be reviewed
- No external dependencies for merge

## 🎉 Made with love

![Gif](https://media.giphy.com/media/13HgwGsXF0aiGY/giphy.gif)
