### PR TITLE
Require explicit branch creation confirmation and add defaultPrompt option

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,3 +26,9 @@ This is a monorepo, so when editing a subproject, prefer to run commands in the 
 - When a test is wrong, always fix it, unless you tried three times and it is still failing. In this case, ask for help;
 - If you find errors in the code tested, report them before trying to fix them. Explain why it's wrong so the dev can evaluate it. Never ask for permission to do so, just report it;
 - When mocking a function or object, avoid mocking through index files, as they'll export readonly elements. Mock using direct paths to the file that declares them instead.
+
+# About Pull Requests
+
+- Pull request must be in english
+- Follow PR template;
+- A random GIF images must be selected and added to the PR description for fun;

--- a/.release-it.base.js
+++ b/.release-it.base.js
@@ -1,5 +1,15 @@
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
+
+const cwd = process.cwd();
+const pkgPath = path.resolve(cwd, 'package.json');
+if (!fs.existsSync(pkgPath)) {
+  throw new Error('package.json not found in current working directory: ' + cwd);
+}
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+const top = execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+if (!top) throw new Error('Unable to determine git repository top-level directory');
 
 const commitTemplatePath = path.resolve(__dirname, 'commit.hbs');
 let commitTemplate = fs.existsSync(commitTemplatePath)
@@ -17,25 +27,16 @@ function normalizeRepoUrl(raw) {
     url = `https://${sshMatch[1]}/${sshMatch[2]}`;
   }
   // If it's an scp-like ssh url (ssh://git@...), remove the ssh://
-  url = url.replace(/^ssh:\/\//, 'https://');
+  url = url.replace(/^ssh:\/\//, 'https://').replace(/\/$/, '');
   return url;
 }
 
 function detectRepoUrl() {
-  try {
-    const pkgPath = path.resolve(process.cwd(), 'package.json');
-    if (fs.existsSync(pkgPath)) {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath).toString());
-      const repo = pkg.repository && (pkg.repository.url || pkg.repository);
-      const normalized = normalizeRepoUrl(repo);
-      if (normalized) return normalized;
-    }
-  } catch (e) {
-    // ignore
-  }
+  const repo = pkg.repository && (pkg.repository.url || pkg.repository);
+  const normalized = normalizeRepoUrl(repo);
+  if (normalized) return normalized;
 
   try {
-    const { execSync } = require('child_process');
     const raw = execSync('git config --get remote.origin.url', { encoding: 'utf8' }).trim();
     const normalized = normalizeRepoUrl(raw);
     if (normalized) return normalized;
@@ -51,22 +52,31 @@ const typeMap = {
   fix: 'Fixes:',
 }
 
-// Get package name from package.json
-function getPackageName() {
-  try {
-    const pkgPath = path.resolve(process.cwd(), 'package.json');
-    if (fs.existsSync(pkgPath)) {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-      return pkg.name;
-    }
-  } catch (e) {
-    // ignore
+const packageName = pkg.name;
+const repoUrl = detectRepoUrl();
+
+// Derive owner/repository from repoUrl for gh API calls (single place)
+let ghOwner = '';
+let ghRepo = '';
+if (repoUrl) {
+  const _m = repoUrl.match(/^https?:\/\/[^\/]+\/([^\/]+)\/([^\/]+)(?:\/|$)/);
+  if (_m) {
+    ghOwner = _m[1];
+    ghRepo = _m[2];
   }
-  return null;
 }
 
-const packageName = getPackageName();
-const repoUrl = detectRepoUrl();
+if (!ghOwner || !ghRepo) throw new Error('Unable to determine GitHub owner/repository from repository URL: ' + repoUrl);
+
+// Detect packageManager from repository root package.json (prefers git top-level)
+function getRootPackageManager() {
+  if (pkg.packageManager && typeof pkg.packageManager === 'string') {
+    return pkg.packageManager.split('@')[0];
+  }
+  return "npm";
+}
+
+const rootPackageManager = getRootPackageManager();
 if (repoUrl && commitTemplate.indexOf('/commit/{{hash}}') !== -1) {
   // replace any hardcoded commit host path with the detected repo URL
   // matches patterns like https://github.com/owner/repo/commit/{{hash}}
@@ -79,20 +89,50 @@ if (repoUrl && commitTemplate.indexOf('/commit/{{hash}}') !== -1) {
 
 /** @type {import('release-it').ReleaseConfig} **/
 module.exports = {
-  git: {
-    tagName: '${npm.name}@${version}',
-    commitMessage: 'chore(${npm.name}): release v${version} [skip ci]',
-    requireCleanWorkingDir: false,
-    commitsPath: '.',
-    push: true,
-    pushRepo: 'origin',
-    requireCommits: false
+  git: (function () {
+    // Decide tagName based on whether we're at the repository root (monorepo handling)
+    let tagName = 'v${version}';
+    let commitMessage = 'chore: release v${version} [skip ci]';
+    try {
+      if (path.resolve(top) !== path.resolve(cwd)) {
+        // Not at repo root -> try to use package name
+        if (packageName) {
+          tagName = packageName + '@${version}';
+          commitMessage = 'chore(release): release ' + packageName + '@${version} [skip ci]';
+        }
+      }
+    } catch (e) {
+      // keep defaults on any error
+    }
+    return {
+      tagName,
+      commitMessage,
+      requireCleanWorkingDir: false,
+      commitsPath: '.',
+      push: true,
+      pushRepo: 'origin',
+      requireCommits: false
+    };
+  })(),
+  npm: {
+    publish: false,
+    skipChecks: true,
+    versionArgs: '--workspaces=false'
   },
-  npm: { publish: false, skipChecks: true },
+  hooks: (function () {
+    if (pkg && pkg.scripts && pkg.scripts['custom:publish']) {
+      const mgr = rootPackageManager === 'pnpm' ? 'pnpm' : 'npm';
+      return { 'after:bump': `${mgr} run custom:publish` };
+    }
+
+    if (rootPackageManager === 'pnpm') {
+      return {
+        'after:bump': 'pnpm publish --no-git-checks'
+      };
+    }
+    return {};
+  })(),
   github: { release: false },
-  hooks: {
-    'after:bump': 'pnpm publish --no-git-checks'
-  },
   plugins: {
     '@release-it/conventional-changelog': {
       preset: {
@@ -112,23 +152,122 @@ module.exports = {
         format: '%s%n%n%b%n%H',
       },
       writerOpts: {
-        commitPartial: commitTemplate,
-        headerPartial: '## [{{version}}]({{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{packageName}}@{{version}}) ({{date}})',
-        finalizeContext: function (context) {
+  commitPartial: commitTemplate,
+  headerPartial: `{{#if repoUrl}}
+## [{{version}}]({{repoUrl}}/compare/{{previousTag}}...{{currentTag}}) ({{date}})
+
+{{#if pullRequests}}
+### Pull Requests:
+
+{{#each pullRequests}}- {{#if this.markdown}}{{{this.markdown}}}{{else}}#{{this.number}}{{/if}}
+{{/each}}
+{{/if}}
+{{else}}
+## [{{version}}]({{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{currentTag}}) ({{date}})
+
+{{#if pullRequests}}
+### Pull Requests:
+
+{{#each pullRequests}}- {{#if this.markdown}}{{{this.markdown}}}{{else}}#{{this.number}}{{/if}}
+{{/each}}
+{{/if}}
+{{/if}}`,
+    finalizeContext: function (context) {
+          // Primary source for Pull Requests: scan git commits between previousTag and currentTag
           context.packageName = packageName;
+          try {
+            const prev = context.previousTag || '';
+            let curr = context.currentTag || '';
+            // If currentTag is present but doesn't resolve yet (dry-run computed tag), fall back to HEAD
+            if (curr) {
+              try {
+                execSync(`git rev-parse --verify --quiet ${curr}`);
+              } catch (e) {
+                curr = '';
+              }
+            }
+            const range = prev ? `${prev}..${(curr || 'HEAD')}` : (curr || 'HEAD');
+            const gitOut = execSync(`git log ${range} --pretty=format:%s%n%b`, { encoding: 'utf8' });
+            const prsSet = new Set();
+            for (const m of gitOut.matchAll(/(?:Merge pull request\s+#|#)(\d+)\b/ig)) {
+              if (m[1]) prsSet.add(m[1]);
+            }
+            // Also catch 'pull request 123' patterns
+            for (const m of gitOut.matchAll(/pull request\s+#?(\d+)/ig)) {
+              if (m[1]) prsSet.add(m[1]);
+            }
+            const prs = Array.from(prsSet).map(n => Number(n)).filter(n => !isNaN(n)).sort((a, b) => a - b).map(String);
+            // Build PR objects with markdown links when repo base is available
+            let prBase = null;
+            if (repoUrl) {
+              // `repoUrl` is already normalized by detectRepoUrl()
+              prBase = repoUrl.replace(/\/$/, '');
+            }
+
+            if (prBase) {
+              context.pullRequests = prs.map(n => {
+                const url = prBase + '/pull/' + n;
+                let markdown = `[#${n}](${url})`;
+                  try {
+                      const ghOut = execSync(`gh api repos/${ghOwner}/${ghRepo}/pulls/${n} --method GET -H "Accept: application/vnd.github.v3+json"`, { encoding: 'utf8' });
+                      const pr = JSON.parse(ghOut);
+                      const prWebUrl = (pr && (pr.html_url || pr.htmlUrl)) || url;
+                      if (pr && pr.title) markdown = `[#${n} - ${pr.title.replace(/\n/g, ' ')}](${prWebUrl})`;
+                  } catch (e) {
+                    console.error(`Warning: unable to fetch PR #${n} details via gh CLI: ${e.message}`);
+                  }
+                return { number: n, url, markdown };
+              });
+            } else {
+              // fallback to plain text number if we can't determine repo base
+              context.pullRequests = prs.map(n => ({ number: n, markdown: `#${n}` }));
+            }
+            // Ensure host/owner/repository are available for templates that build URLs
+            try {
+              let host = context.host || '';
+              let owner = context.owner || '';
+              let repository = context.repository || '';
+              if ((!host || !owner || !repository) && repoUrl) {
+                const m = repoUrl.match(/^https?:\/\/([^\/]+)\/([^\/]+)\/([^\/]+)(?:\/|$)/);
+                if (m) {
+                  host = m[1];
+                  owner = m[2];
+                  repository = m[3];
+                }
+              }
+              if ((!host || !owner || !repository)) {
+                try {
+                  const raw = execSync('git config --get remote.origin.url', { encoding: 'utf8' }).trim();
+                  const normalized = normalizeRepoUrl(raw);
+                  const m2 = normalized && normalized.match(/^https?:\/\/([^\/]+)\/([^\/]+)\/([^\/]+)(?:\/|$)/);
+                  if (m2) {
+                    host = host || m2[1];
+                    owner = owner || m2[2];
+                    repository = repository || m2[3];
+                  }
+                } catch (e) {
+                  // ignore
+                }
+              }
+                context.host = host;
+                context.owner = owner;
+                context.repository = repository;
+                if (repoUrl) context.repoUrl = repoUrl;
+            } catch (e) {
+              // ignore
+            }
+          } catch (e) {
+            context.pullRequests = [];
+          }
           return context;
         },
         transform: function (commit) {
           const out = Object.assign({}, commit);
 
-          // Filter out release commits (they shouldn't appear in changelog)
-          if (out.type === 'chore' && out.scope && /release v\d+\.\d+\.\d+/.test(out.subject)) {
-            return null;
-          }
-
           // Map commit type to section title
           const typeTitle = typeMap[out.type];
-          if (typeTitle) out.type = typeTitle;
+          if (!typeTitle) return null;
+          out.type = typeTitle;
 
           if (out.hash && typeof out.hash === 'string') out.hash = out.hash.substring(0, 7);
           // If hash wasn't provided separately, try to extract it from the end of the body

--- a/libs/mcp-pr-command/src/internal/build-copilot-prompt.ts
+++ b/libs/mcp-pr-command/src/internal/build-copilot-prompt.ts
@@ -34,6 +34,17 @@ const commonInstructions = `
 
 const placeholderRegex = /%(\w+)%/g;
 
+function getBasePrompt() {
+	if (typeof context.defaultPrompt === 'object') {
+		return `${commonInstructions}
+
+# Complementary information
+
+${context.defaultPrompt.additional}`;
+	}
+	return context.defaultPrompt ?? commonInstructions;
+}
+
 export function buildCopilotPrompt({
 	prTemplate,
 	prContentFile,
@@ -53,7 +64,7 @@ export function buildCopilotPrompt({
 	);
 
 	if (context.language) placeHolders.LANGUAGE = context.language;
-	let basePrompt = context.basePullRequestPrompt ?? commonInstructions;
+	let basePrompt = getBasePrompt();
 	basePrompt = basePrompt.replace(
 		placeholderRegex,
 		(_match, key: string) => placeHolders[key] ?? _match,

--- a/libs/mcp-pr-command/src/internal/internal-options.ts
+++ b/libs/mcp-pr-command/src/internal/internal-options.ts
@@ -35,7 +35,11 @@ export interface InternalOptions {
 	cardLinkWebSitePattern?: RegExp;
 	prLinkInferPattern?: string;
 	language?: string;
-	basePullRequestPrompt?: string;
+	defaultPrompt?:
+		| string
+		| {
+				additional: string;
+		  };
 	branchSchema: BranchSchema | BranchSchemaCallback;
 	branchMapping: Record<ChangingBranchType, BranchMappingItem>;
 }

--- a/libs/mcp-pr-command/src/mcp-pr-command-options.ts
+++ b/libs/mcp-pr-command/src/mcp-pr-command-options.ts
@@ -90,7 +90,11 @@ export interface McpPRCommandOptions {
 	 *   - Respect template structure when adding card links.\n
 	 *   - Card information may go just below card link.\n   * `
 	 */
-	defaultPrompt?: string;
+	defaultPrompt?:
+		| string
+		| {
+				additional: string;
+		  };
 
 	/**
 	 * Complementary description to be used by the MCP for additional context.

--- a/libs/mcp-pr-command/src/tools/create-branch.tool.ts
+++ b/libs/mcp-pr-command/src/tools/create-branch.tool.ts
@@ -26,6 +26,9 @@ const inputSchema = {
 		.describe(
 			'Optional base branch to create the new branch from. If not informed will be chosen based on branch schema. Only inform this if user explicitly requests so.',
 		),
+	userExplicitlyRequestedCreation: z
+		.boolean()
+		.describe('Indicates if the user explicitly requested branch creation'),
 	cwd: z
 		.string()
 		.min(1)
@@ -59,7 +62,9 @@ If type is specified within user prompt, use that instead.
 This examples are the defualt branch schema, too. You can inform the user
 of this default values if questioned about it.
 
-IMPORTANT: If user requests to open a PR, don't use this tool, as he's already positioned in the correct branch.
+IMPORTANT:
+* If user requests to open a PR, don't use this tool, as he's already positioned in the correct branch.
+* Only use this tool if user explicitly requests to create a branch.
 `,
 				inputSchema,
 				outputSchema,
@@ -82,6 +87,12 @@ IMPORTANT: If user requests to open a PR, don't use this tool, as he's already p
 	): Promise<McpResult<typeof outputSchema>> {
 		const { type, suffix, baseBranch } = params;
 		const schema = getBranchSchema();
+
+		if (!params.userExplicitlyRequestedCreation) {
+			throw new Error(
+				'Branch creation aborted: user did not explicitly request branch creation.',
+			);
+		}
 
 		// Determine default base branch if not provided
 		const defaultBase = schema[context.branchMapping[type].origin] ?? 'main';

--- a/libs/mcp-pr-command/test/unit/internal/build-copilot-prompt.default-object.spec.ts
+++ b/libs/mcp-pr-command/test/unit/internal/build-copilot-prompt.default-object.spec.ts
@@ -1,0 +1,19 @@
+import { buildCopilotPrompt, context } from 'src/internal';
+
+describe('buildCopilotPrompt (defaultPrompt as object)', () => {
+	const additionalText = 'Some additional complementary information.';
+
+	beforeAll(() => {
+		// ensure language does not interfere with this test
+		delete context.language;
+	});
+
+	it('should include additional text from defaultPrompt.additional', () => {
+		const oldPrompt = context.defaultPrompt;
+		context.defaultPrompt = { additional: additionalText } as any;
+		const prompt = buildCopilotPrompt({ changesFile: 'changes.txt' });
+		expect(prompt).toContain(additionalText);
+		expect(prompt).toContain('changes.txt');
+		context.defaultPrompt = oldPrompt;
+	});
+});

--- a/libs/mcp-pr-command/test/unit/internal/build-copilot-prompt.no-language.spec.ts
+++ b/libs/mcp-pr-command/test/unit/internal/build-copilot-prompt.no-language.spec.ts
@@ -15,12 +15,12 @@ describe('buildCopilotPrompt (no language in context)', () => {
 	});
 
 	it('should replace placeholder in custom basePullRequestPrompt', () => {
-		const oldPrompt = context.basePullRequestPrompt;
-		context.basePullRequestPrompt = 'Hello %LANGUAGE%!';
+		const oldPrompt = context.defaultPrompt;
+		context.defaultPrompt = 'Hello %LANGUAGE%!';
 		const prompt = buildCopilotPrompt({ changesFile: 'file.txt' });
 		expect(prompt).toContain(
 			'Hello same language of README.MD, commits or pull request template!',
 		);
-		context.basePullRequestPrompt = oldPrompt;
+		context.defaultPrompt = oldPrompt;
 	});
 });

--- a/libs/mcp-pr-command/test/unit/internal/build-copilot-prompt.with-language.spec.ts
+++ b/libs/mcp-pr-command/test/unit/internal/build-copilot-prompt.with-language.spec.ts
@@ -16,10 +16,10 @@ describe('buildCopilotPrompt (with language in context)', () => {
 	});
 
 	it('should replace placeholder in custom basePullRequestPrompt', () => {
-		const oldPrompt = context.basePullRequestPrompt;
-		context.basePullRequestPrompt = 'Hello %LANGUAGE%!';
+		const oldPrompt = context.defaultPrompt;
+		context.defaultPrompt = 'Hello %LANGUAGE%!';
 		const prompt = buildCopilotPrompt({ changesFile: 'file.txt' });
 		expect(prompt).toContain('Hello Portuguese!');
-		context.basePullRequestPrompt = oldPrompt;
+		context.defaultPrompt = oldPrompt;
 	});
 });

--- a/libs/mcp-pr-command/test/unit/internal/gh-client-api.spec.ts
+++ b/libs/mcp-pr-command/test/unit/internal/gh-client-api.spec.ts
@@ -55,12 +55,10 @@ describe('GhApiClient', () => {
 		const request = jest
 			.fn()
 			.mockResolvedValue({ data: { items: [{ number: 77 }] } });
-		const OctokitMock = jest
-			.fn()
-			.mockImplementation(() => ({
-				rest: { pulls: { list: pullsList } },
-				request,
-			}));
+		const OctokitMock = jest.fn().mockImplementation(() => ({
+			rest: { pulls: { list: pullsList } },
+			request,
+		}));
 		jest.doMock('@octokit/rest', () => ({ Octokit: OctokitMock }));
 
 		const { GhApiClient } = require('src/internal/gh-client-api');
@@ -80,11 +78,9 @@ describe('GhApiClient', () => {
 		}));
 
 		const get = jest.fn().mockRejectedValue(new Error('boom'));
-		const request = jest
-			.fn()
-			.mockResolvedValue({
-				data: { items: [{ title: 'S', body: 'B', html_url: 'U' }] },
-			});
+		const request = jest.fn().mockResolvedValue({
+			data: { items: [{ title: 'S', body: 'B', html_url: 'U' }] },
+		});
 		const OctokitMock = jest
 			.fn()
 			.mockImplementation(() => ({ rest: { pulls: { get } }, request }));
@@ -119,12 +115,10 @@ describe('GhApiClient', () => {
 		}));
 
 		const create = jest.fn().mockResolvedValue({ data: {} });
-		const OctokitMock = jest
-			.fn()
-			.mockImplementation(() => ({
-				rest: { pulls: { create } },
-				request: jest.fn(),
-			}));
+		const OctokitMock = jest.fn().mockImplementation(() => ({
+			rest: { pulls: { create } },
+			request: jest.fn(),
+		}));
 		jest.doMock('@octokit/rest', () => ({ Octokit: OctokitMock }));
 
 		const fsPromises = require('fs/promises');
@@ -149,22 +143,21 @@ describe('GhApiClient', () => {
 				if (cmd === 'gh auth token') return 'token';
 				// first two candidates throw, third returns a mixed remote list that includes a matching url
 				if (call <= 2) throw new Error('boom');
-				if (cmd.includes('git'))
-					{return 'origin	git@github.com:good/rep.git (fetch)\norigin	ssh://git@github.com:bad/skip.git (push)';}
+				if (cmd.includes('git')) {
+					return 'origin	git@github.com:good/rep.git (fetch)\norigin	ssh://git@github.com:bad/skip.git (push)';
+				}
 				return '';
 			},
 		}));
 
-		const OctokitMock = jest
-			.fn()
-			.mockImplementation(() => ({
-				request: jest.fn(),
-				rest: {
-					pulls: {
-						list: jest.fn().mockResolvedValue({ data: [{ number: 1 }] }),
-					},
+		const OctokitMock = jest.fn().mockImplementation(() => ({
+			request: jest.fn(),
+			rest: {
+				pulls: {
+					list: jest.fn().mockResolvedValue({ data: [{ number: 1 }] }),
 				},
-			}));
+			},
+		}));
 		jest.doMock('@octokit/rest', () => ({ Octokit: OctokitMock }));
 
 		const { GhApiClient } = require('src/internal/gh-client-api');
@@ -193,12 +186,10 @@ describe('GhApiClient', () => {
 	it('prCreate throws when owner/repo cannot be resolved', async () => {
 		// no git remotes -> resolveOwnerRepoOrThrow should throw
 		jest.doMock('src/internal/run', () => ({ run: async () => '' }));
-		const OctokitMock = jest
-			.fn()
-			.mockImplementation(() => ({
-				request: jest.fn(),
-				rest: { pulls: { create: jest.fn() } },
-			}));
+		const OctokitMock = jest.fn().mockImplementation(() => ({
+			request: jest.fn(),
+			rest: { pulls: { create: jest.fn() } },
+		}));
 		jest.doMock('@octokit/rest', () => ({ Octokit: OctokitMock }));
 
 		const fsPromises = require('fs/promises');
@@ -407,12 +398,10 @@ describe('GhApiClient', () => {
 		}));
 
 		const update = jest.fn().mockResolvedValue({});
-		const OctokitMock = jest
-			.fn()
-			.mockImplementation(() => ({
-				rest: { pulls: { update } },
-				request: jest.fn(),
-			}));
+		const OctokitMock = jest.fn().mockImplementation(() => ({
+			rest: { pulls: { update } },
+			request: jest.fn(),
+		}));
 		jest.doMock('@octokit/rest', () => ({ Octokit: OctokitMock }));
 
 		const fsPromises = require('fs/promises');

--- a/libs/mcp-pr-command/test/unit/internal/git-service.edge.spec.ts
+++ b/libs/mcp-pr-command/test/unit/internal/git-service.edge.spec.ts
@@ -31,8 +31,9 @@ describe('GitService edge cases', () => {
 		// make run throw for show-ref and ls-remote
 		jest.doMock('src/internal/run', () => ({
 			run: jest.fn().mockImplementation(async (cmd: string) => {
-				if (cmd.includes('ls-remote') || cmd.includes('show-ref'))
-					{throw new Error('not found');}
+				if (cmd.includes('ls-remote') || cmd.includes('show-ref')) {
+					throw new Error('not found');
+				}
 				return '';
 			}),
 			command: (cmd: string) => ({

--- a/libs/mcp-pr-command/test/unit/tools/create-branch.tool.spec.ts
+++ b/libs/mcp-pr-command/test/unit/tools/create-branch.tool.spec.ts
@@ -4,7 +4,20 @@ import { gitService } from '../../../src/internal/git-service';
 describe('CreateBranchTool', () => {
 	beforeEach(() => jest.restoreAllMocks());
 
-	test('createBranchHandler creates branch name and calls gitService', async () => {
+	test('createBranchHandler throws if user did not explicitly request creation', async () => {
+		const cb = new CreateBranchTool();
+		await expect(
+			cb.createBranchHandler({
+				type: 'feat',
+				suffix: 'My Feature',
+				cwd: process.cwd(),
+			} as any),
+		).rejects.toThrow(
+			'Branch creation aborted: user did not explicitly request branch creation.',
+		);
+	});
+
+	test('createBranchHandler creates branch name and calls gitService when explicitly requested', async () => {
 		jest.spyOn(gitService, 'tryFetch').mockResolvedValue(undefined as any);
 		const checkoutSpy = jest
 			.spyOn(gitService, 'checkoutBranch')
@@ -14,6 +27,7 @@ describe('CreateBranchTool', () => {
 			type: 'feat',
 			suffix: 'My Feature',
 			cwd: process.cwd(),
+			userExplicitlyRequestedCreation: true,
 		} as any);
 		expect(res.structuredContent?.branchName).toBe('feat/my-feature');
 		expect(checkoutSpy).toHaveBeenCalled();


### PR DESCRIPTION
### 🔨 What does this PR do?

- Improves changelog formatting and generation.
- Requires explicit user confirmation when creating branches via the orchestrator to avoid accidental branch creation.
- Adds a new `defaultPrompt` option that accepts an object with `additional` to extend the MCP base prompt.

## Type

- [ ] addition
- [x] change
- [x] fix
- [ ] removal
- [ ] sync
- [ ] release

## Objectives

What is being changed? Checklist:

- Update `.release-it.base.js`:
  - Better repository and owner/repo detection.
  - Use `git rev-parse --show-toplevel` to identify repository root.
  - Adjust changelog generation to include pull requests found in the git log and try to fetch PR titles via `gh api` when available.
  - Introduce logic to detect root `packageManager` and conditionally set publish hooks.
  - Make the changelog writer more resilient and monorepo-aware.
- Refactor `build-copilot-prompt.ts` to support `defaultPrompt` as an object with `additional`.
- Update typings (`internal-options.ts` and `mcp-pr-command-options.ts`) to accept `defaultPrompt` as string or object with `additional`.
- `create-branch.tool.ts`:
  - Add `userExplicitlyRequestedCreation` in the input schema.
  - Abort branch creation when the user didn't explicitly request it (throws an error).
  - Update usage notes to emphasize the tool runs only on explicit request.
- Add/update unit tests to cover the new behavior.

## Screenshot

N/A

## Tests/How to test?

- Run tests for `libs/mcp-pr-command`:

```
cd libs/mcp-pr-command
npm run test
```

- Or from the workspace root:

```
npm run test --workspace libs/mcp-pr-command
```

- Run `npm run lint` / `npm run lint:fix` if needed.
- Verify:
  - Branch creation attempt without `userExplicitlyRequestedCreation` fails with appropriate error message.
  - `buildCopilotPrompt` includes `defaultPrompt.additional` when present.
  - `release-it` behavior remains correct (run a dry-run if necessary).

## Deploy

- Safe to merge after review and CI passes.
- No npm publish by default (`npm.publish: false` in the release configuration).
- If a `custom:publish` script exists on the root `package.json`, it will be run according to the detected package manager.

## 🎉 Made with love

![fun coding gif](https://media.giphy.com/media/ICOgUNjpvO0PC/giphy.gif)
